### PR TITLE
Add artifacts build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build Artifacts
+on:
+  push:
+    branches:
+      - "*"
+  workflow_dispatch:
+
+jobs:
+  build_artifcats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jar
+          path: build/libs/
+          retention-days: 30


### PR DESCRIPTION
I've added a simple GitHub actions build pipeline which builds the gradle `build` target and provides the compiled jar in the job artifacts when run. The pipeline will trigger on each push to any branch.

This should make play-testing a little bit easier, I hope.